### PR TITLE
fix: handle imported classes differently to avoid upvalue limit

### DIFF
--- a/src/luavisitor.ts
+++ b/src/luavisitor.ts
@@ -154,22 +154,7 @@ if not __exports then return end
                 }
             }
 
-            if (this.imports.length > 0) {
-                /*
-                 * Only create the __imports table if we are importing
-                 * anything not from a global module.
-                 */
-                let hasImports = false;
-                for (const imp of this.imports) {
-                    if (globalModules[imp.module] === undefined) {
-                        hasImports = true;
-                        break;
-                    }
-                }
-                if (hasImports) {
-                    prehambule += "local __imports = {}\n";
-                }
-            }
+            let hasImportsTable = false;
             for (const imp of this.imports) {
                 let moduleVariableName: string;
                 if (imp.variables && imp.variables.every((x) => x.usages == 0))
@@ -198,11 +183,19 @@ if not __exports then return end
                         } else {
                             fullModuleName = `${this.appName}/${imp.path}`;
                         }
+                        if (!hasImportsTable) {
+                            hasImportsTable = true;
+                            prehambule += "local __imports = {};\n";
+                        }
                         prehambule += `__imports.${moduleVariableName} = LibStub:GetLibrary("${fullModuleName}")\n`;
                     } else {
                         const extras = this.packageExtras.getExtras(imp.module);
                         let moduleName = extras.lua.name;
                         fullModuleName = `"${moduleName}"`;
+                        if (!hasImportsTable) {
+                            hasImportsTable = true;
+                            prehambule += "local __imports = {};\n";
+                        }
                         if (extras.lua?.isGlobal) {
                             prehambule += `__imports.${moduleVariableName} = ${moduleName}\n`;
                         } else {


### PR DESCRIPTION
Reduce the number of upvalues referenced within a closure by
changing the way that `new Class(...)` is transpiled into Lua.

The old way added a file-local variable for each class that was
imported from a module, and `new Class(...)` directly upvalued
to the file-local variable. Unfortunately, if a closure created
instances of more than 60 classes, then the WoW client limit of
60 upvalues is reached and the addon fails to load.

The new way adds a `__imports` table that contains all of the
imported symbols, and `new Class(...)` is transpiled into
`__imports.Class(...)`. This uses only a single upvalue for the
import table instead of an upvalue for each class constructor.

Sort all of the additions to the `__imports` table ahead of all of
the local aliasing of the imported symbols to make it more visually
pleasing.