### PR TITLE
test: add unit tests for recent import changes

### DIFF
--- a/src/luavisitor.ts
+++ b/src/luavisitor.ts
@@ -185,7 +185,7 @@ if not __exports then return end
                         }
                         if (!hasImportsTable) {
                             hasImportsTable = true;
-                            prehambule += "local __imports = {};\n";
+                            prehambule += "local __imports = {}\n";
                         }
                         prehambule += `__imports.${moduleVariableName} = LibStub:GetLibrary("${fullModuleName}")\n`;
                     } else {


### PR DESCRIPTION
These two commits fix a small codegen issue with an uneccessary
semicolon, and add unit tests for the changes to the codegen for
symbols imported from modules.